### PR TITLE
Scope current match for person by active matches

### DIFF
--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -27,7 +27,7 @@ class Person < ActiveRecord::Base
   end
 
   def current_match
-    Match.where("newcomer_id = ? OR established_id = ?", id, id).last
+    Match.active.where("newcomer_id = ? OR established_id = ?", id, id).last
   end
 
   def currently_matched_with


### PR DESCRIPTION
I'm pretty sure this is how we want it. The current match for a person should probably not refer to an inactive match. Then it would be impossible to create a new match, which I believe should be possible if an old match has been concluded.