### PR TITLE
Allow destruction of people and matches

### DIFF
--- a/admin/app/policies/admin/person_policy.rb
+++ b/admin/app/policies/admin/person_policy.rb
@@ -19,11 +19,7 @@ module Admin
     end
 
     def destroy?
-      if record.newcomer?
-        record.newcomer_matches.empty?
-      else
-        record.established_matches.empty?
-      end
+      true
     end
   end
 end

--- a/app/models/match.rb
+++ b/app/models/match.rb
@@ -12,10 +12,6 @@ class Match < ApplicationRecord
   validate :newcomer_and_established_are_different, on: :create
   validate :newcomer_and_established_are_unmatched, on: :create
 
-  def matched_with(person)
-    newcomer == person ? established : newcomer
-  end
-
   scope :pending, (-> { where(started_at: nil) })
   scope :started, (-> { where.not(started_at: nil) })
   scope :active, (-> { started.where("concluded_at >= ?", Time.zone.now) })
@@ -31,6 +27,10 @@ class Match < ApplicationRecord
     concluded.where(conclusion_mail_sent_at: nil)
              .where(send_conclusion_mail: true)
   })
+
+  def matched_with(person)
+    newcomer == person ? established : newcomer
+  end
 
   def pending?
     started_at.nil?

--- a/app/models/person.rb
+++ b/app/models/person.rb
@@ -5,8 +5,10 @@ class Person < ApplicationRecord
   enum gender: { male: 0, female: 1, other: 2 }
   enum status: { established: 0, newcomer: 1 }
 
-  has_many :newcomer_matches, foreign_key: "newcomer_id", class_name: "Match", inverse_of: "newcomer"
-  has_many :established_matches, foreign_key: "established_id", class_name: "Match", inverse_of: "established"
+  has_many :newcomer_matches, foreign_key: "newcomer_id", class_name: "Match",
+                              inverse_of: "newcomer", dependent: :destroy
+  has_many :established_matches, foreign_key: "established_id", class_name: "Match",
+                                 inverse_of: "established", dependent: :destroy
 
   validates :name, presence: true
   validates :age, numericality: { allow_blank: true, only_integer: true }


### PR DESCRIPTION
This PR simplifies things a bit by allowing for destroying people, with and without matches. Destroying a person will destroy all of the associated matches as well.